### PR TITLE
added variable bin sizes

### DIFF
--- a/ssdilep/algs/algs.py
+++ b/ssdilep/algs/algs.py
@@ -1057,6 +1057,15 @@ class CutAlg(pyframe.core.Algorithm):
             return True;
         return False
 
+    def cut_ZMassWindowMediumLLHisolLooseWide(self):
+        electrons = self.store['electrons_tight_MediumLLH_isolLoose']
+        mZ = 91.1876*GeV
+        if len(electrons)==2 :
+          if (electrons[0].tlv + electrons[1].tlv).M() < 130*GeV:
+            if (electrons[0].tlv + electrons[1].tlv).M() > 60*GeV:
+              return True;
+        return False
+
     #__________________________________________________________________________
     def cut_PASS(self):
       return True
@@ -1592,9 +1601,12 @@ class PlotAlgZee(pyframe.algs.CutFlowAlg,CutAlg):
         # should probably make this configurable
         ## get event candidate
         electrons  = self.store['electrons_tight_MediumLLH_isolLoose']
+        met_trk    = self.store['met_trk']
+        met_clus   = self.store['met_clus']
         
         EVT    = os.path.join(region, 'event')
         ELECTRONS = os.path.join(region, 'electrons')
+        MET    = os.path.join(region, 'met')
         
         # -----------------
         # Create histograms
@@ -1604,9 +1616,16 @@ class PlotAlgZee(pyframe.algs.CutFlowAlg,CutAlg):
         self.h_actualIntPerXing = self.hist('h_actualIntPerXing', "ROOT.TH1F('$', ';actualInteractionsPerCrossing;Events', 50, -0.5, 49.5)", dir=EVT)
         self.h_NPV = self.hist('h_NPV', "ROOT.TH1F('$', ';NPV;Events', 35, 0., 35.0)", dir=EVT)
         self.h_nelectrons = self.hist('h_nelectrons', "ROOT.TH1F('$', ';N_{e};Events', 8, 0, 8)", dir=EVT)
-        self.h_invMass = self.hist('h_invMass', "ROOT.TH1F('$', ';m(ee) [GeV];Events / (1 GeV)', 40, 70, 110)", dir=EVT)
+        self.h_invMass = self.hist('h_invMass', "ROOT.TH1F('$', ';m(ee) [GeV];Events / (1 GeV)', 150, 50, 200)", dir=EVT)
         self.h_ZbosonPt = self.hist('h_ZbosonPt', "ROOT.TH1F('$', ';p_{T}(Z) [GeV];Events / (1 GeV)', 2000, 0, 2000)", dir=EVT)
         self.h_ZbosonEta = self.hist('h_ZbosonEta', "ROOT.TH1F('$', ';#eta(e);Events / (0.1)', 120, -6.0, 6.0)", dir=EVT)
+        ## met plots
+        self.h_met_clus_et = self.hist('h_met_clus_et', "ROOT.TH1F('$', ';E^{miss}_{T}(clus) [GeV];Events / (1 GeV)', 2000, 0.0, 2000.0)", dir=MET)
+        self.h_met_clus_phi = self.hist('h_met_clus_phi', "ROOT.TH1F('$', ';#phi(E^{miss}_{T}(clus));Events / (0.1)', 64, -3.2, 3.2)", dir=MET)
+        self.h_met_trk_et = self.hist('h_met_trk_et', "ROOT.TH1F('$', ';E^{miss}_{T}(trk) [GeV];Events / (1 GeV)', 2000, 0.0, 2000.0)", dir=MET)
+        self.h_met_trk_phi = self.hist('h_met_trk_phi', "ROOT.TH1F('$', ';#phi(E^{miss}_{T}(trk));Events / (0.1)', 64, -3.2, 3.2)", dir=MET)
+        self.h_met_clus_sumet = self.hist('h_met_clus_sumet', "ROOT.TH1F('$', ';#Sigma E_{T}(clus) [GeV];Events / (1 GeV)', 2000, 0.0, 2000.0)", dir=MET)
+        self.h_met_trk_sumet = self.hist('h_met_trk_sumet', "ROOT.TH1F('$', ';#Sigma E_{T}(trk) [GeV];Events / (1 GeV)', 2000, 0.0, 2000.0)", dir=MET)
 
         ##Electron plots
         self.h_el_pt = self.hist('h_el_pt', "ROOT.TH1F('$', ';p_{T}(e) [GeV];Events / (1 GeV)', 2000, 0.0, 2000.0)", dir=ELECTRONS)
@@ -1640,6 +1659,13 @@ class PlotAlgZee(pyframe.algs.CutFlowAlg,CutAlg):
           self.h_invMass.Fill( (electrons[0].tlv+electrons[1].tlv).M()/GeV, weight)
           self.h_ZbosonPt.Fill( (electrons[0].tlv+electrons[1].tlv).Pt()/GeV, weight)
           self.h_ZbosonEta.Fill( (electrons[0].tlv+electrons[1].tlv).Eta(), weight)
+          ## met plots
+          self.h_met_clus_et.Fill(met_clus.tlv.Pt()/GeV, weight)
+          self.h_met_clus_phi.Fill(met_clus.tlv.Phi(), weight)
+          self.h_met_trk_et.Fill(met_trk.tlv.Pt()/GeV, weight)
+          self.h_met_trk_phi.Fill(met_trk.tlv.Phi(), weight)
+          self.h_met_clus_sumet.Fill(met_clus.sumet/GeV, weight)
+          self.h_met_trk_sumet.Fill(met_trk.sumet/GeV, weight)
 
           
           #electron

--- a/ssdilep/plots/var.py
+++ b/ssdilep/plots/var.py
@@ -21,9 +21,11 @@ class Var(object):
             title = None,
             path  = None,
             rebin = None,
+            rebinVar = [],
             xmin  = None,
             xmax  = None,
             log   = None,
+            logx  = None,
             ):
         self.name = name
         if not title: title = name
@@ -34,9 +36,11 @@ class Var(object):
         self.title = title
         self.path  = path
         self.rebin = rebin
+        self.rebinVar = rebinVar
         self.xmin  = xmin
         self.xmax  = xmax
         self.log   = log
+        self.logx  = logx
 
 
 

--- a/ssdilep/plots/vars_ee.py
+++ b/ssdilep/plots/vars_ee.py
@@ -7,6 +7,7 @@ variables for the ee channel
 
 ## modules
 from var import Var
+from funcs import generateLogBins
 
 ## Cutflows
 ## ---------------------------------------
@@ -14,6 +15,10 @@ cutflow_ZWindowSS           = Var(name = 'cutflow_ZWindowSS',log=False)
 cutflow_weighted_ZWindowSS  = Var(name = 'cutflow_weighted_ZWindowSS',log=False)
 cutflow_ZWindowOS           = Var(name = 'cutflow_ZWindowOS',log=False)
 cutflow_weighted_ZWindowOS  = Var(name = 'cutflow_weighted_ZWindowOS',log=False)
+
+## Non-equidistant bins
+## ---------------------------------------
+bins_pt = generateLogBins(60,30,2000)
 
 
 
@@ -57,13 +62,14 @@ invMass = Var(name='invMass',
               xmin   = 70,
               xmax   = 110,
               #rebin  = 10,
-              log    = False,
+              log    = True,
               )
 ZbosonPt = Var(name='ZbosonPt',
                path   = 'event',
                xmin   = 0.,
                xmax   = 2000.,
-               log    = False,
+               rebin  = 50,
+               log    = True,
                )
 ZbosonEta = Var(name='ZbosonEta',
                 path   = 'event',
@@ -76,10 +82,12 @@ ZbosonEta = Var(name='ZbosonEta',
 ## ---------------------------------------
 el_lead_pt = Var(name = 'el_lead_pt',
               path   = 'electrons',
-              xmin   = 0.,
-              xmax   = 1000.,
-              rebin  = 50,
+              xmin   = 30.,
+              xmax   = 2000.,
+              rebin  = 1,
+              rebinVar  = bins_pt,
               log    = True,
+              logx   = True,
               )
 
 el_sublead_pt = Var(name = 'el_sublead_pt',
@@ -276,7 +284,6 @@ vars_list.append(ZbosonEta)
 
 vars_dict = {}
 for var in vars_list: vars_dict[var.name] = var.__dict__
-
 
 ## EOF
 

--- a/ssdilep/run/j.plotter_ZPeak.py
+++ b/ssdilep/run/j.plotter_ZPeak.py
@@ -151,6 +151,24 @@ def analyze(config):
     ## --------------------------------------- 
 
     loop += ssdilep.algs.algs.PlotAlgZee(
+            region   = 'ZWindowOSWide',
+            plot_all = False,
+            cut_flow = [
+               ['ExactlyTwoTightEleMediumLLHisolLooseOS',['ExactlyTwoTightEleSF_MediumLLH_isolLoose']],
+               ['ZMassWindowMediumLLHisolLooseWide',None],
+               ],
+            )
+
+    loop += ssdilep.algs.algs.PlotAlgZee(
+            region   = 'ZWindowSSWide',
+            plot_all = False,
+            cut_flow = [
+               ['ExactlyTwoTightEleMediumLLHisolLooseSS',['ExactlyTwoTightEleSF_MediumLLH_isolLoose']],
+               ['ZMassWindowMediumLLHisolLooseWide',None],
+               ],
+            )
+
+    loop += ssdilep.algs.algs.PlotAlgZee(
             region   = 'ZWindowOS',
             plot_all = False,
             cut_flow = [

--- a/ssdilep/samples/sample.py
+++ b/ssdilep/samples/sample.py
@@ -24,7 +24,7 @@ class Sample(object):
                  name          = '',
                  tlatex        = None,
                  xsec          = 0.0,
-                 feff          = 9.0, 
+                 feff          = 1.0, 
                  kfactor       = 1.0,
                  files         = [],
                  type          = "mc",

--- a/ssdilep/samples/samples.py
+++ b/ssdilep/samples/samples.py
@@ -696,6 +696,54 @@ Zee = Sample( name =   'Zee',
                               ],
                 ) 
 
+#-----
+# Zee Sherpa 2.2.1
+#-----
+
+Zee_221_Pt0_70_CVetoBVeto         = Sample( name =  "Sherpa_221_NNPDF30NNLO_Zee_Pt0_70_CVetoBVeto",                xsec = 1586.66000797 ) 
+Zee_221_Pt70_140_CVetoBVeto       = Sample( name =  "Sherpa_221_NNPDF30NNLO_Zee_Pt70_140_CVetoBVeto",              xsec = 74.392831376  )
+Zee_221_Pt140_280_CVetoBVeto      = Sample( name =  "Sherpa_221_NNPDF30NNLO_Zee_Pt140_280_CVetoBVeto",             xsec = 24.406766768  )
+Zee_221_Pt280_500_CVetoBVeto      = Sample( name =  "Sherpa_221_NNPDF30NNLO_Zee_Pt280_500_CVetoBVeto",             xsec = 4.747987696   )
+
+                                                                                                         
+Zee_221_Pt0_70_CFilterBVeto       = Sample( name =  "Sherpa_221_NNPDF30NNLO_Zee_Pt0_70_CFilterBVeto",              xsec = 218.160449136 )
+Zee_221_Pt70_140_CFilterBVeto     = Sample( name =  "Sherpa_221_NNPDF30NNLO_Zee_Pt70_140_CFilterBVeto",            xsec = 19.829640036  )
+Zee_221_Pt140_280_CFilterBVeto    = Sample( name =  "Sherpa_221_NNPDF30NNLO_Zee_Pt140_280_CFilterBVeto",           xsec = 9.138632129   )
+Zee_221_Pt280_500_CFilterBVeto    = Sample( name =  "Sherpa_221_NNPDF30NNLO_Zee_Pt280_500_CFilterBVeto",           xsec = 2.223207556   )
+
+                                                                                                         
+Zee_221_Pt0_70_BFilter            = Sample( name =  "Sherpa_221_NNPDF30NNLO_Zee_Pt0_70_BFilter",                   xsec = 123.301682947 )
+Zee_221_Pt70_140_BFilter          = Sample( name =  "Sherpa_221_NNPDF30NNLO_Zee_Pt70_140_BFilter",                 xsec = 12.308466245  )
+Zee_221_Pt140_280_BFilter         = Sample( name =  "Sherpa_221_NNPDF30NNLO_Zee_Pt140_280_BFilter",                xsec = 5.931173859   )
+Zee_221_Pt280_500_BFilter         = Sample( name =  "Sherpa_221_NNPDF30NNLO_Zee_Pt280_500_BFilter",                xsec = 1.457160985   )
+
+Zee_221_Pt500_1000                = Sample( name =  "Sherpa_221_NNPDF30NNLO_Zee_MAXHTPTV500_1000",                 xsec = 1.76307831    )
+Zee_221_Pt1000_E_CM               = Sample( name =  "Sherpa_221_NNPDF30NNLO_Zee_MAXHTPTV1000_E_CMS.root",          xsec = 0.144870607   )
+
+
+Zee221 = Sample( name =   'Zee',
+                  tlatex = 'Sherpa.221 Z #rightarrow ee+jets',
+                  fill_color = ROOT.kOrange+1,
+                  line_color =  ROOT.kOrange+2,
+                  marker_color =  ROOT.kOrange+2,
+                  daughters = [
+                               Zee_221_Pt0_70_CVetoBVeto,        
+                               Zee_221_Pt70_140_CVetoBVeto,                                    
+                               Zee_221_Pt140_280_CVetoBVeto,     
+                               Zee_221_Pt280_500_CVetoBVeto,     
+                               Zee_221_Pt0_70_CFilterBVeto,      
+                               Zee_221_Pt70_140_CFilterBVeto,    
+                               Zee_221_Pt140_280_CFilterBVeto,   
+                               Zee_221_Pt280_500_CFilterBVeto,   
+                               Zee_221_Pt0_70_BFilter,           
+                               Zee_221_Pt70_140_BFilter,         
+                               Zee_221_Pt140_280_BFilter,        
+                               Zee_221_Pt280_500_BFilter,        
+                               Zee_221_Pt500_1000,
+                               Zee_221_Pt1000_E_CM,   
+                              ],
+                ) 
+
 
 #-------
 # Zmumu
@@ -1038,7 +1086,8 @@ all_mc += WenuPowheg.daughters
 #all_mc += Zmumu.daughters
 #all_mc += Ztautau.daughters
 
-all_mc += ZeePowheg.daughters
+all_mc += Zee221.daughters
+#all_mc += ZeePowheg.daughters
 #all_mc += ZmumuPowheg.daughters
 #all_mc += ZtautauPowheg.daughters
 

--- a/ssdilep/scripts/merge.py
+++ b/ssdilep/scripts/merge.py
@@ -44,7 +44,7 @@ parser.add_option('-t', '--tag', dest='tag',
 # Configuration
 #-----------------
 #lumi =  3158.13
-lumi =  3212.96
+lumi =  18084.1
 #lumi =  18232.8
 #lumi = 5000
 
@@ -73,16 +73,18 @@ data = samples.data
 mc_backgrounds = [
     #samples.diboson_sherpa,
     #samples.diboson_powheg,
-    samples.WZ,
-    samples.ZZ,
-    samples.WW,
-    samples.Wenu,
-    samples.Wmunu,
-    samples.Wtaunu,
+    #samples.WZ,
+    #samples.ZZ,
+    #samples.WW,
+    #samples.Wenu,
+    #samples.Wmunu,
+    #samples.Wtaunu,
     #samples.mytestSample,
     samples.ZeePowheg,
-    samples.Zmumu,
-    samples.Ztautau,
+    samples.WenuPowheg,
+    samples.diboson_sherpa,
+    #samples.Zmumu,
+    #samples.Ztautau,
     #samples.ttX,
     #samples.singletop,
     samples.ttbar,
@@ -148,21 +150,22 @@ mumu_vdict  = vars_ee.vars_dict
 ## order backgrounds for plots
 mumu_backgrounds = [
     #samples.diboson_sherpa,
-  #samples.diboson_powheg,
-    samples.WZ,
-    samples.ZZ,
-    samples.WW,  
-    samples.Wenu,
-    samples.Wmunu,
-    samples.Wtaunu,
-    samples.ZeePowheg,
+    #samples.diboson_powheg,
+    #samples.WZ,
+    #samples.ZZ,
+    #samples.WW,
+    #samples.Wenu,
+    #samples.Wmunu,
+    #samples.Wtaunu,
     #samples.mytestSample,
-    samples.Zmumu,
-    samples.Ztautau,
+    samples.ZeePowheg,
+    samples.WenuPowheg,
+    samples.diboson_sherpa,
+    #samples.Zmumu,
+    #samples.Ztautau,
     #samples.ttX,
     #samples.singletop,
     samples.ttbar,
-    #fakes_mumu,
     ]
 
 """
@@ -195,7 +198,9 @@ if options.makeplot == "True":
     xmin          = mumu_vdict[options.vname]['xmin'],
     xmax          = mumu_vdict[options.vname]['xmax'],
     rebin         = mumu_vdict[options.vname]['rebin'],
+    rebinVar      = mumu_vdict[options.vname]['rebinVar'],
     log           = mumu_vdict[options.vname]['log'],
+    logx          = mumu_vdict[options.vname]['logx'],
     icut          = int(options.icut),
     #sys_dict      = sys_dict,
     sys_dict      = None,

--- a/test/plotMiha.sh
+++ b/test/plotMiha.sh
@@ -3,8 +3,8 @@
 # Strings are passed to the scrieta but this is redundant!
 
 #electron variables
-python ../ssdilep/scripts/merge.py --var="el_lead_pt" --reg="ZWindowSS" --lab="" --tag="Powheg" --icut="1" --input="/ceph/grid/home/atlas/miham/AnalysisCode/EXOT12" --output="./Plots" --makeplot=True --fakest=""
-python ../ssdilep/scripts/merge.py --var="el_sublead_pt" --reg="ZWindowSS" --lab="" --tag="Powheg" --icut="1" --input="/ceph/grid/home/atlas/miham/AnalysisCode/EXOT12" --output="./Plots" --makeplot=True --fakest=""
+python ../ssdilep/scripts/merge.py --var="el_lead_pt" --reg="ZWindowOS" --lab="" --tag="Powheg" --icut="1" --input="/ceph/grid/home/atlas/miham/AnalysisCode/EXOT12" --output="./Plots" --makeplot=True --fakest=""
+'''python ../ssdilep/scripts/merge.py --var="el_sublead_pt" --reg="ZWindowSS" --lab="" --tag="Powheg" --icut="1" --input="/ceph/grid/home/atlas/miham/AnalysisCode/EXOT12" --output="./Plots" --makeplot=True --fakest=""
 python ../ssdilep/scripts/merge.py --var="el_lead_eta" --reg="ZWindowSS" --lab="" --tag="Powheg" --icut="1" --input="/ceph/grid/home/atlas/miham/AnalysisCode/EXOT12" --output="./Plots" --makeplot=True --fakest=""
 python ../ssdilep/scripts/merge.py --var="el_subead_eta" --reg="ZWindowSS" --lab="" --tag="Powheg" --icut="1" --input="/ceph/grid/home/atlas/miham/AnalysisCode/EXOT12" --output="./Plots" --makeplot=True --fakest=""
 python ../ssdilep/scripts/merge.py --var="el_lead_phi" --reg="ZWindowSS" --lab="" --tag="Powheg" --icut="1" --input="/ceph/grid/home/atlas/miham/AnalysisCode/EXOT12" --output="./Plots" --makeplot=True --fakest=""
@@ -26,7 +26,4 @@ python ../ssdilep/scripts/merge.py --var="actualIntPerXing" --reg="ZWindowOS" --
 python ../ssdilep/scripts/merge.py --var="ZbosonPt" --reg="ZWindowOS" --lab="" --tag="Powheg" --icut="1" --input="/ceph/grid/home/atlas/miham/AnalysisCode/EXOT12" --output="./Plots" --makeplot=True --fakest=""
 python ../ssdilep/scripts/merge.py --var="ZbosonEta" --reg="ZWindowOS" --lab="" --tag="Powheg" --icut="1" --input="/ceph/grid/home/atlas/miham/AnalysisCode/EXOT12" --output="./Plots" --makeplot=True --fakest=""
 
-
-
-
-
+'''


### PR DESCRIPTION
Hi @fscutti , @gucchiel , @kmankinen ,

I added an option to have variable x-bins. Below is an example plot. Note that the bins appear equidistant because the plot is in log-x scale.

![temp](https://cloud.githubusercontent.com/assets/12948551/20102628/0fdb8788-a5c7-11e6-8c8d-196f8f21be93.png)

The config would look something like this:

```
el_lead_pt = Var(name = 'el_lead_pt',
              path   = 'electrons',
              xmin   = 30.,
              xmax   = 2000.,
              rebin  = 1,
              rebinVar  = bins_pt,
              log    = True,
              logx   = True,
              )
```

where rebinVar should be an array with bin edges, e.g. rebinVar = [30,100,300,2000]





